### PR TITLE
Add missing Pulse attributes: Pulse#tlp and Pulse#public

### DIFF
--- a/lib/otx_ruby/types/indicators.rb
+++ b/lib/otx_ruby/types/indicators.rb
@@ -6,6 +6,8 @@ module OTX
   # @attr [String] indicator Value of the indicator type
   # @attr [String] type Type of IoC
   # @attr [String] description Description associated with the IoC
+  # @attr [String] title
+  # @attr [String] content
   #
   # Indicator of Compromise types:
   #   IPv4 - An IPv4 address indicating the online location of a server or other computer.
@@ -26,6 +28,6 @@ module OTX
   #   CVE - Common Vulnerability and Exposure (CVE) entry describing a software vulnerability that can be exploited to engage in malicious activity.
   #
   class Indicators < OTX::Type::Base
-    attr_accessor :_id, :indicator, :type, :description
+    attr_accessor :_id, :indicator, :type, :description, :title, :content
   end
 end

--- a/lib/otx_ruby/types/pulse.rb
+++ b/lib/otx_ruby/types/pulse.rb
@@ -11,15 +11,17 @@ module OTX
   # @attr [Array<String>] referenes Array of references attached to the pulse
   # @attr [String] revision Revision number of the OTX Pulse Record
   # @attr [Array<OTX::Indicators>] indicators Array of the IoC attached to the OTX pulse
+  # @attr [String] tlp Traffic light protocol color as appropriate to U.S. DHS
+  # @attr [Boolean] public Privacy setting
   #
   class Pulse < OTX::Type::Base
     attr_accessor :id, :name, :description, :author_name,
-      :tags, :references, :revision, :indicators
+      :tags, :references, :revision, :indicators, :tlp, :public
 
     def initialize(attributes={})
       attributes.each do |key, value|
         if key != 'indicators'
-          send("#{key}=", value)
+          send("#{key.downcase}=", value)
         else
           @indicators = []
           value.each do |indicator|

--- a/lib/otx_ruby/types/pulse.rb
+++ b/lib/otx_ruby/types/pulse.rb
@@ -14,13 +14,14 @@ module OTX
   # @attr [String] tlp Traffic light protocol color as appropriate to U.S. DHS
   # @attr [Boolean] public Privacy setting
   # @attr [Boolean] in_group
-  # @attr [Boolean] group_id
-  # @attr [Boolean] group_name
+  # @attr [String] group_id
+  # @attr [String] group_name
+  # @attr [Array<String>] groups
   #
   class Pulse < OTX::Type::Base
     attr_accessor :id, :name, :description, :author_name,
       :tags, :references, :revision, :indicators, :tlp, :public, :in_group,
-      :group_id, :group_name
+      :group_id, :group_name, :groups
 
     def initialize(attributes={})
       attributes.each do |key, value|

--- a/lib/otx_ruby/types/pulse.rb
+++ b/lib/otx_ruby/types/pulse.rb
@@ -17,11 +17,15 @@ module OTX
   # @attr [String] group_id
   # @attr [String] group_name
   # @attr [Array<String>] groups
+  # @attr [String] adversary
+  # @attr [Array<String>] targeted_countries
+  # @attr [Array<String>] industries
   #
   class Pulse < OTX::Type::Base
     attr_accessor :id, :name, :description, :author_name,
       :tags, :references, :revision, :indicators, :tlp, :public, :in_group,
-      :group_id, :group_name, :groups
+      :group_id, :group_name, :groups, :adversary, :targeted_countries,
+      :industries
 
     def initialize(attributes={})
       attributes.each do |key, value|

--- a/lib/otx_ruby/types/pulse.rb
+++ b/lib/otx_ruby/types/pulse.rb
@@ -13,10 +13,14 @@ module OTX
   # @attr [Array<OTX::Indicators>] indicators Array of the IoC attached to the OTX pulse
   # @attr [String] tlp Traffic light protocol color as appropriate to U.S. DHS
   # @attr [Boolean] public Privacy setting
+  # @attr [Boolean] in_group
+  # @attr [Boolean] group_id
+  # @attr [Boolean] group_name
   #
   class Pulse < OTX::Type::Base
     attr_accessor :id, :name, :description, :author_name,
-      :tags, :references, :revision, :indicators, :tlp, :public
+      :tags, :references, :revision, :indicators, :tlp, :public, :in_group,
+      :group_id, :group_name
 
     def initialize(attributes={})
       attributes.each do |key, value|


### PR DESCRIPTION
See #1 

Adds support for new Pulse parameters `TLP` and `public`
